### PR TITLE
Separate production and inverter try in main loop

### DIFF
--- a/scraper/scrape.py
+++ b/scraper/scrape.py
@@ -93,7 +93,7 @@ def scrape_stream():
                                 if key in stream_gauges:
                                     stream_gauges[key].labels(type=meter_type, phase=phase).set(value)
         except requests.exceptions.RequestException as e:
-            print('Exception fetching stream data: %s' % e)
+            print('Exception fetching meter stream data: %s' % e)
             time.sleep(5)
 
 
@@ -138,9 +138,12 @@ def main():
     while True:
         try:
             scrape_production_json()
+        except Exception as e:
+            print('Exception fetching production scrape data: %s' % e)
+        try:    
             scrape_inverters()
         except Exception as e:
-            print('Exception fetching scrape data: %s' % e)
+            print('Exception fetching inverter scrape data: %s' % e)
         time.sleep(60)
 
 


### PR DESCRIPTION
I ran into failure to pull data from inverters, due to failure to find consumption data.
Since my inverter does not monitor consumption data, it isn't reporting it as expected.
Modification is to separate production and inverter scraping into separate try/exception operations.
Also added the word "meter" to the error for /stream/meter, since my envoy doesn't support that, and the error helps clarify where the failure is.